### PR TITLE
fix bug to use oursin with rasterLayer

### DIFF
--- a/oursinsdialog.py
+++ b/oursinsdialog.py
@@ -86,16 +86,18 @@ class OursinsDialog(QtGui.QDialog, Ui_Oursins):
             return
         self.outputFilename.setText(fileName)
 
-    def populateLayers( self ):
+    def populateLayers( self):
 	self.inputLayers.clear()     #InputLayer 
         myListLayers = []
-        myListLayers = [layer.name() for layer in qgis.QgsMapLayerRegistry.instance().mapLayers().values() if layer.geometryType() == qgis.QGis.Polygon or layer.geometryType() == qgis.QGis.Point ]
+        myListLayers = [layer.name() for layer in qgis.QgsMapLayerRegistry.instance().mapLayers().values() 
+            if hasattr(layer, 'geometryType') and (layer.geometryType() == qgis.QGis.Polygon or layer.geometryType() == qgis.QGis.Point) ]
         self.inputLayers.addItems( myListLayers )
 
     def populateTables( self ):
 	self.inputFlowTable.clear()     #InputTable
         myList = []
-        myList = [layer.name() for layer in qgis.QgsMapLayerRegistry.instance().mapLayers().values() if layer.geometryType() == qgis.QGis.NoGeometry ]
+        myList = [layer.name() for layer in qgis.QgsMapLayerRegistry.instance().mapLayers().values() 
+            if hasattr(layer, 'geometryType') and layer.geometryType() == qgis.QGis.NoGeometry ]
         self.inputFlowTable.addItems( myList )
 
     def populateAttributesLayers( self ):


### PR DESCRIPTION
Hi,
when a rasterLayer is loaded, oursin main dialog won't show up. 
If the layer type is rasterLayer, then  the **geometryType** method does not exist.
This patch should fix this problem.

Best regards,